### PR TITLE
Removed registration of Windows log due to error when connector is used...

### DIFF
--- a/Log/LogFactory.cs
+++ b/Log/LogFactory.cs
@@ -28,7 +28,7 @@ namespace MWS.Log
             _logs = new ArrayList();
 
             // register logs
-            RegisterLog(Log);
+            // RegisterLog(Log);
         }
 
         public static void RegisterLog(LogInterface log)


### PR DESCRIPTION
Removed registration of Windows log due to error when connector is used as an external library.
